### PR TITLE
Refactor the package

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [8.*]
+        laravel: [^8.71, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.23
+          - testbench: 7.*
+            laravel: 9.*
+          - testbench: ^6.6
+            laravel: ^8.71
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 ## Credits
 
 - [Olsza](https://github.com/olsza)
+- [Michael Rubel](https://github.com/michael-rubel)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Contains value objects:
 
-- TaxNumber
+- [TaxNumber](https://github.com/olsza/value-objects/blob/main/src/TaxNumber.php)
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "type": "project",
     "require": {
-        "php": "^7.0|^8.0",
+        "php": "^8.0",
         "michael-rubel/laravel-formatters": "^3.1.0"
     },
     "require-dev": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,6 @@ parameters:
     checkOctaneCompatibility: true
     checkModelProperties: true
     checkMissingIterableValueType: false
+    ignoreErrors:
+        - '#Property Olsza\\ValueObjects\\TaxNumber\:\:\$tax_number \(string\) does not accept mixed\.#'
+        - '#Method Olsza\\ValueObjects\\TaxNumber\:\:format\(\) should return string but returns mixed\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,12 +2,10 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: max
     paths:
         - src
-        - src/Interfaces
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
     checkMissingIterableValueType: false
-

--- a/src/Interfaces/TaxNumberInterface.php
+++ b/src/Interfaces/TaxNumberInterface.php
@@ -7,16 +7,16 @@ namespace Olsza\ValueObjects\Interfaces;
 interface TaxNumberInterface
 {
     /**
-     * @param string      $tax_number
-     * @param string|null $country
+     * @param string $tax_number
+     * @param string $country
      */
-    public function __construct(string $tax_number = '', ?string $country = '');
+    public function __construct(string $tax_number = '', string $country = '');
 
     /**
-     * @param string|null $tax_number
-     * @param string|null $country
+     * @param string $tax_number
+     * @param string $country
      *
      * @return mixed
      */
-    public static function make(?string $tax_number = null, ?string $country = null): mixed;
+    public static function make(string $tax_number = '', string $country = ''): mixed;
 }

--- a/src/Interfaces/TaxNumberInterface.php
+++ b/src/Interfaces/TaxNumberInterface.php
@@ -6,13 +6,17 @@ namespace Olsza\ValueObjects\Interfaces;
 
 interface TaxNumberInterface
 {
-    public function __construct(
-        string $taxNumber = '',
-        ?string $country = ''
-    );
+    /**
+     * @param string      $tax_number
+     * @param string|null $country
+     */
+    public function __construct(string $tax_number = '', ?string $country = '');
 
-    public static function make(
-        ?string $taxNumber = null,
-        ?string $country = null
-    );
+    /**
+     * @param string|null $tax_number
+     * @param string|null $country
+     *
+     * @return mixed
+     */
+    public static function make(?string $tax_number = null, ?string $country = null): mixed;
 }

--- a/src/TaxNumber.php
+++ b/src/TaxNumber.php
@@ -104,7 +104,7 @@ class TaxNumber implements TaxNumberInterface
     private function transform(): void
     {
         $this->when($this->lengthIsLessOrEqualTwo(), function () {
-            $this->country    = (string) Str::of($this->tax_number)
+            $this->country = (string) Str::of($this->tax_number)
                 ->substr(0, 2)
                 ->upper();
 
@@ -122,7 +122,7 @@ class TaxNumber implements TaxNumberInterface
     {
         return $this->tax_number = format(TaxNumberFormatter::class, [
             'country_iso' => $this->country,
-            'tax_number'  => $this->tax_number,
+            'tax_number' => $this->tax_number,
         ]);
     }
 

--- a/src/TaxNumber.php
+++ b/src/TaxNumber.php
@@ -135,7 +135,7 @@ class TaxNumber implements TaxNumberInterface
     {
         return format(TaxNumberFormatter::class, [
             'country_iso' => $country,
-            'tax_number' => $taxNumber,
+            'tax_number'  => $taxNumber,
         ]);
     }
 

--- a/src/TaxNumber.php
+++ b/src/TaxNumber.php
@@ -4,51 +4,57 @@ declare(strict_types=1);
 
 namespace Olsza\ValueObjects;
 
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use MichaelRubel\Formatters\Collection\TaxNumberFormatter;
 use Olsza\ValueObjects\Interfaces\TaxNumberInterface;
 
 class TaxNumber implements TaxNumberInterface
 {
+    use Conditionable;
+
     /**
      * Create a new TaxNumber instance.
      *
-     * @param string $taxNumber
+     * @param string $tax_number
      * @param string|null $country
      */
     public function __construct(
-        private string $taxNumber = '',
+        private string $tax_number = '',
         private ?string $country = ''
     ) {
-        $this->separationData($taxNumber, $country ?? '');
+        $this->format();
+        $this->transform();
     }
 
     /**
      * Return a new instance of TaxNumber.
      *
-     * @param string|null $taxNumber
+     * @param string|null $tax_number
      * @param string|null $country
      * @return static
      */
     public static function make(
-        ?string $taxNumber = null,
+        ?string $tax_number = null,
         ?string $country = null
     ): TaxNumber {
-        return new static($taxNumber, $country);
+        return new static($tax_number, $country);
     }
 
     /**
-     * Set the Tax Number for a given value object.
+     * Set the tax number for a given value object.
      *
-     * @param string $taxNumber
+     * @param string $tax_number
+     *
      * @return void
      */
-    public function setTaxNumber(string $taxNumber): void
+    public function setTaxNumber(string $tax_number): void
     {
-        $this->taxNumber = trim($taxNumber);
+        $this->tax_number = trim($tax_number);
     }
 
     /**
-     * Set the Country for a given value object.
+     * Set the country for a given value object.
      *
      * @param string $country
      * @return void
@@ -59,27 +65,28 @@ class TaxNumber implements TaxNumberInterface
     }
 
     /**
-     * Get a Tax Number for a given value object.
+     * Get the tax number.
      *
      * @return string|null
      */
     public function getTaxNumber(): ?string
     {
-        return strtoupper($this->taxNumber);
+        return Str::upper($this->tax_number);
     }
 
     /**
-     * Get a Country for a given value object.
+     * Get the country prefix.
      *
      * @return string
      */
     public function getCountry(): string
     {
-        return strtoupper($this->country);
+        return Str::upper($this->country);
     }
 
     /**
-     * Get a Full Tax Number for a given value object. Tax Number with prefix Country
+     * Get a full tax number for a given value object.
+     * The tax number with a country prefix.
      *
      * @return string
      */
@@ -89,54 +96,43 @@ class TaxNumber implements TaxNumberInterface
     }
 
     /**
-     * Sets the appropriate data.
-     *
-     * @param string $taxNumber
-     * @param string $country
+     * Transforms the data to appropriate form.
      *
      * @return void
      */
-    private function separationData(
-        string $taxNumber = '',
-        string $country = ''
-    ): void {
-        $tempTaxNumber = $this->preFilterTax($taxNumber, $country);
-        $country = strtoupper($country);
-        if (strlen($taxNumber) >= 2) {
-            $tempCountry = substr($tempTaxNumber, 0, 2);
-            $tempNumber = substr($tempTaxNumber, 2);
-        } else {
-            $tempNumber = substr($tempTaxNumber, strlen($country));
-            $tempCountry = $country;
-        }
+    private function transform(): void
+    {
+        $this->when($this->lengthIsLessOrEqualTwo(), function () {
+            $this->country    = (string) Str::of($this->tax_number)
+                ->substr(0, 2)
+                ->upper();
 
-        if (empty($country)) {
-            $this->setCountry($tempCountry);
-            $this->setTaxNumber($tempNumber);
-        } else {
-            $this->setCountry($country);
-
-            if ($tempCountry == $country) {
-                $this->setTaxNumber($tempNumber);
-            } else {
-                $this->setTaxNumber($tempTaxNumber);
-            }
-        }
+            $this->tax_number = (string) Str::of($this->tax_number)
+                ->substr(2);
+        });
     }
 
     /**
-     * Filters data about Tax Number.
+     * Format the tax number.
      *
-     * @param string|null $taxNumber
-     * @param string|null $country
      * @return string
      */
-    private function preFilterTax(?string $taxNumber, ?string $country = null): string
+    private function format(): string
     {
-        return format(TaxNumberFormatter::class, [
-            'country_iso' => $country,
-            'tax_number'  => $taxNumber,
+        return $this->tax_number = format(TaxNumberFormatter::class, [
+            'country_iso' => $this->country,
+            'tax_number'  => $this->tax_number,
         ]);
+    }
+
+    /**
+     * Check if the tax number length is less or equal two.
+     *
+     * @return bool
+     */
+    private function lengthIsLessOrEqualTwo(): bool
+    {
+        return strlen($this->tax_number) >= 2;
     }
 
     /**

--- a/src/TaxNumber.php
+++ b/src/TaxNumber.php
@@ -17,11 +17,11 @@ class TaxNumber implements TaxNumberInterface
      * Create a new TaxNumber instance.
      *
      * @param string $tax_number
-     * @param string|null $country
+     * @param string $country
      */
     public function __construct(
         private string $tax_number = '',
-        private ?string $country = ''
+        private string $country = ''
     ) {
         $this->format();
         $this->transform();
@@ -30,13 +30,14 @@ class TaxNumber implements TaxNumberInterface
     /**
      * Return a new instance of TaxNumber.
      *
-     * @param string|null $tax_number
-     * @param string|null $country
+     * @param string $tax_number
+     * @param string $country
+     *
      * @return static
      */
     public static function make(
-        ?string $tax_number = null,
-        ?string $country = null
+        string $tax_number = '',
+        string $country = ''
     ): TaxNumber {
         return new static($tax_number, $country);
     }


### PR DESCRIPTION
This PR introduces plenty of changes:
- Refactors the `TaxNumber VO` to make it better maintainable for future updates.
- Raises the required version of PHP to `8.0`, as the class itself uses the PHP 8.0 features already, so it makes no sense to allow the users to install it through Composer.
- Raises PHPStan level to `max` to prevent potential code quality issues in the future.
- Adds the test suite for Laravel 9.
- Updates ReadMe.md.